### PR TITLE
tech: Add GitHub Actions workflow automating releases

### DIFF
--- a/.github/workflows/job_build_ffi.yml
+++ b/.github/workflows/job_build_ffi.yml
@@ -1,0 +1,64 @@
+name: "Build Pact FFI"
+
+on:
+  workflow_call:
+    inputs:
+      repo-owner:
+        required: true
+        type: string
+      repo-name:
+        required: true
+        type: string
+
+jobs:
+  buildFFI:
+    name: "🚧  Build libpact_ffi.a"
+    runs-on: macos-14
+    timeout-minutes: 60
+    strategy:
+      fail-fast: true
+
+    steps:
+      - name: "♻️ Checkout repository"
+        uses: actions/checkout@v4
+
+      - name: "♼ Cache rust binaries"
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ github.workspace }}
+          key: build-ffi-${{ runner.os }}-${{ hashFiles('**/Package.swift') }}
+          restore-keys: |
+            build-ffi-${{ runner.os }}
+
+      - name: "🔍  Check for cached files"
+        id: check_files
+        uses: andstor/file-existence-action@v3
+        with:
+          files: "PactSwiftMockServer/**/libpact_ffi.version"
+
+      - name: "🧑‍🤝‍🧑 Clone ${{ inputs.repo-owner }}/${{ inputs.repo-name }}"
+        uses: GuillaumeFalourd/clone-github-repo-action@v2.1
+        if: steps.check_files.outputs.files_exists == 'false'
+        with:
+          depth: 1
+          owner: ${{ inputs.repo-owner }}
+          repository: ${{ inputs.repo-name }}
+
+      - name: "🧰  Install required tools"
+        if: steps.check_files.outputs.files_exists == 'false'
+        run: |
+          sh Scripts/install_required_tools
+
+      - name: "🛠️  Build FFI"
+        if: steps.check_files.outputs.files_exists == 'false'
+        run: |
+          cd ${{ inputs.repo-name }}
+          sh ../Scripts/build_ffi_libs
+
+      - name: "🛫  Upload artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+          if-no-files-found: error
+          name: "Resources"
+          path: ${{ inputs.repo-name }}/Resources

--- a/.github/workflows/job_build_xcframework.yml
+++ b/.github/workflows/job_build_xcframework.yml
@@ -1,0 +1,67 @@
+name: "Build XCFramework"
+
+on:
+  workflow_call:
+    inputs:
+      repo-owner:
+        required: true
+        type: string
+      repo-name:
+        required: true
+        type: string
+
+env:
+  XCFRAMEWORK: "PactSwiftMockServer.xcframework"
+  CHECKSUM: "checksum"
+  RESOURCES: Resources
+
+jobs:
+  buildXCFramework:
+    name: "🚧  Build XCFramework"
+    runs-on: macos-14
+    timeout-minutes: 10
+    strategy:
+      fail-fast: true
+
+    steps:
+      - name: "♻️ Checkout repository"
+        uses: actions/checkout@v4
+
+      - name: "🧑‍🤝‍🧑 Clone ${{ inputs.repo-name }}/${{ inputs.repo-name }}"
+        uses: GuillaumeFalourd/clone-github-repo-action@v2.1
+        with:
+          depth: 1
+          owner: ${{ inputs.repo-owner }}
+          repository: ${{ inputs.repo-name }}
+
+      - name: "🧹  Remove ${{ env.RESOURCES }} folder"
+        id: removeResourcesFolder
+        run: |
+          rm -fr ${{ inputs.repo-name }}/${{ env.RESOURCES }}
+
+      - name: "🛬  Download Resources folder"
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.RESOURCES }}
+          path: ${{ inputs.repo-name }}/Resources
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: "🛠️  Build XCFramework"
+        run: |
+          cd ${{ inputs.repo-name }}
+          sh ../Scripts/build_xcframework
+          echo "🚚  Move ${{ env.XCFRAMEWORK }} one level up..."
+          mv ${{ env.XCFRAMEWORK }} ../
+
+      - name: "🕵️  Calculate checksum(s)"
+        run: |
+          find ./${{ env.XCFRAMEWORK }} -type f -not -name "*.sha256" -print0 | xargs -0 shasum -a 256 > ${{ env.XCFRAMEWORK }}.sha256
+
+      - name: "🛫  Upload artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+          name: XCFramework
+          path: |
+            ${{ env.XCFRAMEWORK }}/
+            ${{ env.XCFRAMEWORK }}.sha256

--- a/.github/workflows/job_open_pr.yml
+++ b/.github/workflows/job_open_pr.yml
@@ -1,0 +1,45 @@
+name: "Open a PR"
+
+on:
+  workflow_call:
+    secrets:
+      PR_PAT:
+        required: true
+    inputs:
+      release-version:
+        required: true
+        type: string
+
+jobs:
+  create-pull-request:
+    name: "⛴️  Preapare changes"
+    runs-on: macos-14
+    permissions:
+      id-token: write
+
+    steps:
+      - name: "♻️ Checkout repository"
+        uses: actions/checkout@v4
+
+      - name: "🛬  Add new XCFramework"
+        uses: actions/download-artifact@v4
+        with:
+          name: XCFramework
+          path: Framework
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: "🔏  Setup git sign"
+        uses: chainguard-dev/actions/setup-gitsign@main
+
+      - name: "🍾  Open a PR"
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: "${{ secrets.PR_PAT }}"
+          branch: release/candidate
+          branch-suffix: short-commit-hash
+          delete-branch: true
+          base: main
+          title: "[RELEASE] ${{ inputs.release-version }}"
+          commit-message: "Automated change: Updated version of XCFramework."
+          draft: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: "Release"
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "🚀  Release new version"
+        uses: ncipollo/release-action@v1
+        with:
+          skipIfReleaseExists: true
+          draft: true

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -1,0 +1,61 @@
+name: "Upgrade"
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-version:
+        description: "Version to release"
+        required: true
+        type: string
+        default: "v0.0.0"
+  push:
+    branches-ignore:
+      - main
+
+env:
+  RUST_TARGET_PATH: pact-reference/rust/target
+  BINARIES_PATH: Resources
+  REPO_OWNER: 'surpher'
+  REPO_NAME: 'PactSwiftMockServer'
+
+concurrency:
+  group: build-ffi-binaries-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sharedInputs:
+    name: "🧑‍🤝‍🧑  Shared env vars"
+    runs-on: ubuntu-latest
+    outputs:
+      repo-owner: ${{ env.REPO_OWNER }}
+      repo-name: ${{ env.REPO_NAME }}
+      release-version: ${{ inputs.release-version }}
+    steps:
+      - run: echo "Just a workaround for passing envs to other jobs... ¯\_(ツ)_/¯"
+
+  buildFFI:
+    name: "🏗️  Build FFI"
+    needs: [sharedInputs]
+    uses: ./.github/workflows/job_build_ffi.yml
+    with:
+      repo-owner: ${{ needs.sharedInputs.outputs.repo-owner }}
+      repo-name: ${{ needs.sharedInputs.outputs.repo-name }}
+
+  buildXCFramework:
+    name: "📦  Build XCFramework"
+    needs: [sharedInputs, buildFFI]
+    uses: ./.github/workflows/job_build_xcframework.yml
+    with:
+      repo-owner: ${{ needs.sharedInputs.outputs.repo-owner }}
+      repo-name: ${{ needs.sharedInputs.outputs.repo-name }}
+
+  openPullRequest:
+    needs: [sharedInputs, buildFFI, buildXCFramework]
+    name: "🚀  Open Pull Request"
+    uses: ./.github/workflows/job_open_pr.yml
+    with:
+      release-version: ${{ inputs.release-version }}
+    secrets:
+      PR_PAT: ${{ secrets.PR_PAT }}
+    permissions:
+      id-token: write

--- a/Scripts/build_ffi_libs
+++ b/Scripts/build_ffi_libs
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+
+#  Created by Marko Justinek on 27/8/24.
+#  Copyright © 2024 Marko Justinek. All rights reserved.
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+#  SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+#  IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+set -euo pipefail
+
+SOURCE_DIR="${BASH_SOURCE[0]%/*}"
+
+########################
+# Pre-requisite(s):
+# 	1. ``libpact_ffi.version`` file exists in the "${WORKSPACE}/PactSwiftMockServer" folder.
+#######################
+
+WORKSPACE="${GITHUB_WORKSPACE:-$PWD}"
+PACTSWIFTMOCKSERVER_DIR="$WORKSPACE/PactSwiftMockServer"
+LIBPACT_FFI_DIR="${PACTSWIFTMOCKSERVER_DIR}/pact-reference/rust/pact_ffi"
+LIBPACT_FFI_VERSION=$(awk 'NR==1 {print; exit}' libpact_ffi.version)
+
+# "import"
+source "$SOURCE_DIR/utils.sh"
+source "$SOURCE_DIR/rust_config.sh"
+
+#######################
+# Pre-requisite       #
+#######################
+
+# Check whether this script is being run in the right folder
+if [ ! -d "$PWD/PactSwiftMockServer.xcodeproj" ]
+then
+	echo "🚨  Run this from the same folder where your 'PactSwiftMockServer.xcodeproj' is."
+	echo "⚠️  You are runing it in '$PWD'."
+	exit 1
+fi
+
+# Check Tooling is available
+echo "👮‍♀️  Checking if Rust is installed..."
+if which cargo >/dev/null; then
+	echo "👍  cargo installed"
+elif command -v ~/.cargo/bin/cargo &> /dev/null; then
+	echo "👍  cargo installed in ~/.cargo/bin/"
+else
+	echo "🚨  Rust/Cargo not installed"
+	echo -e "ERROR: 'cargo' is a required dependency.\nInstall Rust using either homebrew or follow instructions at https://www.rust-lang.org/tools/install"
+ 	exit 1
+fi
+
+####################################
+# Rust codebase prep               #
+####################################
+
+# Update pact-reference submodule
+echo "🔃 Updating pact-reference submodule"
+execute_command "git submodule update --init"
+
+echo "ℹ️  Changing location to ${LIBPACT_FFI_DIR}"
+execute_command "cd $LIBPACT_FFI_DIR"
+
+echo "ℹ️  Checking out ${LIBPACT_FFI_VERSION}"
+execute_command "git fetch --all --tags"
+execute_command "git checkout tags/$LIBPACT_FFI_VERSION"
+
+###############################
+# Setup rust environment      #
+###############################
+
+# Set the rust toolchain (prepare_rust_tools.sh)
+# pact-reference/rust/pact_ffi/CMakeLists.txt uses nightly!
+rustup_install_nightly
+
+# Set default rust toolchain for current machine's architecture
+rustup_set_default_toolchain
+
+# Add the required triples for supported architectures
+rustup_add_targets
+
+##############################################
+# Build libpact_ffi binaries                 #
+##############################################
+
+# Set min deployment targets avoiding 'ld: warning's:
+# avoiding "Object file (__/libpact_ffi.a[arm64][232](b0401a448be314bb-zdict.o)) was built for newer 'macOS' version (14.2) than being linked (12.0)"
+unset MACOSX_DEPLOYMENT_TARGET
+export MACOSX_DEPLOYMENT_TARGET=12.0
+
+# avoiding "Object file (__/libpact_ffi.a[arm64][232](b0401a448be314bb-zdict.o)) was built for newer 'iOS-simulator' version (17.2) than being linked (13.0)"
+unset IPHONEOS_DEPLOYMENT_TARGET
+export IPHONEOS_DEPLOYMENT_TARGET=13.0
+
+# Build for x86_64 architectures
+echo "🏗  Building libpact_ffi.a for x86_64 iOS Simulator"
+execute_command "cargo build --target=x86_64-apple-ios --release"
+
+echo "🏗  Building libpact_ffi.a for x86_64 Darwin"
+execute_command "cargo build --target=x86_64-apple-darwin --release"
+
+# Build for arm64 architectures
+echo "🏗  Building libpact_ffi.a for arm64 iOS Simulator"
+execute_command "cargo build --target aarch64-apple-ios-sim --release"
+
+echo "🏗  Building libpact_ffi.a for arm64 Darwin"
+execute_command "cargo build --target=aarch64-apple-darwin --release"
+
+echo "🏗  Building libpact_ffi.a for arm64 iOS device"
+execute_command "cargo build --target=aarch64-apple-ios --release"
+
+echo "✅  libpact_ffi.a binaries built"
+
+echo "🏗  Building pact_ffi.h..."
+execute_command "mkdir -p build && cd build"
+
+execute_command "cmake .. && cmake --build ."
+execute_command "cbindgen .. -o ../include/pact_ffi.h"
+
+execute_command "cd .."
+
+#######################
+# Pact Mock Server    #
+#######################
+
+# Copy the compiled binaries into PactSwiftMockServer project
+echo "🏗  Copying binaries from ${PWD} to ${PACTSWIFTMOCKSERVER_DIR}/Resources"
+
+# Copy binary for an iOS device
+echo "🚚  Copying arm64-ios (iOS device) binary..."
+execute_command "cp ../target/aarch64-apple-ios/release/libpact_ffi.a $PACTSWIFTMOCKSERVER_DIR/Resources/iOS-device/libpact_ffi.a"
+echo "👍  Copied arm64-ios binary."
+
+# Create a fat binary for iOS Simulators and copy to workspace
+echo "🚚  Creating a fat binary for iOS Simulator (x86_64 and arm64)..."
+execute_command "lipo -create \
+  ../target/x86_64-apple-ios/release/libpact_ffi.a \
+  ../target/aarch64-apple-ios-sim/release/libpact_ffi.a \
+  -output $PACTSWIFTMOCKSERVER_DIR/Resources/iOS-simulator/libpact_ffi.a"
+echo "👍  Copied x86_64-ios and arm64-ios-sim fattie."
+
+# Create a fat darwin binary and copy to workspace
+echo "🚚  Copying x86_64-darwin and arm64-darwin into a fat binary..."
+execute_command "lipo -create \
+  ../target/x86_64-apple-darwin/release/libpact_ffi.a \
+  ../target/aarch64-apple-darwin/release/libpact_ffi.a \
+  -output $PACTSWIFTMOCKSERVER_DIR/Resources/x86_64-darwin/libpact_ffi.a"
+echo "👍  Copied x86_64-darwin and arm64-darwin fattie."
+
+echo "🏗  Copying pact_ffi.h from ${PWD}/include to ${PACTSWIFTMOCKSERVER_DIR}/Sources"
+execute_command "cp include/pact_ffi.h ${PACTSWIFTMOCKSERVER_DIR}/Sources"
+
+#######################
+# Cleanup             #
+#######################
+
+echo "🎉  All done!"

--- a/Scripts/build_xcframework
+++ b/Scripts/build_xcframework
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+#  Created by Marko Justinek on 27/8/24.
+#  Copyright © 2024 Marko Justinek. All rights reserved.
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+#  SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+#  IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+set -euo pipefail
+
+SOURCE_DIR="${BASH_SOURCE[0]%/*}"
+
+# "import"
+source "$SOURCE_DIR/utils.sh"
+source "$SOURCE_DIR/config.sh"
+
+# Properties
+TMP_DIR="./.tmp/build-xcframework"
+
+# Only use xcbeautify if it can be found in path.
+XCBEAUTIFY=$(command -v xcbeautify || command -v cat)
+
+########################
+# Pre-build checks     #
+########################
+
+# Check for Xcode version used to generate the XCFramework. Should be at least 12.x.
+# Otherwise a _concurrency fatal issue will be raised if PactSwiftMockSerer is
+# used in a project built with Xcode 12.x
+echo "⚠️ Checking for the right Xcode tools..."
+check_xcode
+
+# Setup
+
+echo "ℹ️  Looking for ${PRODUCT_NAME}.xcodeproj"
+if [ ! -d "${PRODUCT_NAME}.xcodeproj" ]; then
+    echo "🚨 Run this in the same folder as \"${PRODUCT_NAME}.xcodeproj\"."
+    exit 1
+fi
+
+echo "ℹ️  Removing existing XCFramework"
+rm -fr "./${PRODUCT_NAME}.xcframework"
+echo "👍  Removed existing ${PRODUCT_NAME}.xcframework"
+
+echo "ℹ️  Preparing '${TMP_DIR}' folder"
+mkdir -p $TMP_DIR
+rm -fr $TMP_DIR
+
+# iOS
+
+echo "🏗  Building for iOS..."
+xcodebuild archive \
+    -sdk iphoneos IPHONEOS_DEPLOYMENT_TARGET=${IPHONEOS_DEPLOYMENT_TARGET} \
+    -arch arm64 \
+    -scheme "${PRODUCT_NAME}-iphoneos" \
+    -archivePath "${TMP_DIR}/iphoneos/${PRODUCT_NAME}.xcarchive" \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+    SKIP_INSTALL=NO | ${XCBEAUTIFY}
+
+echo "👍  Framework for arm64 device built"
+
+echo "🏗  Building for iOS Simulator..."
+xcodebuild archive \
+    -sdk iphonesimulator IPHONEOS_DEPLOYMENT_TARGET=${IPHONEOS_DEPLOYMENT_TARGET} \
+    -arch x86_64 -arch arm64 \
+    -scheme "${PRODUCT_NAME}-iOS" \
+    -archivePath "${TMP_DIR}/iphonesimulator/${PRODUCT_NAME}.xcarchive" \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+    SKIP_INSTALL=NO | ${XCBEAUTIFY}
+echo "👍  Framework for iOS Simulator built for x86_64 and arm64 architecture"
+
+# macOS
+
+echo "🏗  Building for macOS..."
+xcodebuild archive \
+    -sdk macosx MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} \
+    -arch x86_64 -arch arm64 \
+    -scheme "${PRODUCT_NAME}-macOS" \
+    -archivePath "${TMP_DIR}/macos/${PRODUCT_NAME}.xcarchive" \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
+    SKIP_INSTALL=NO | ${XCBEAUTIFY}
+echo "👍  Framework for macOS built for x86_64 and arm64 architectures"
+
+# XCFramework
+
+echo "🏗  Building XCFramework..."
+xcodebuild -create-xcframework -output ./$PRODUCT_NAME.xcframework \
+    -framework $TMP_DIR/iphoneos/$PRODUCT_NAME.xcarchive/Products/Library/Frameworks/$PRODUCT_NAME.framework \
+    -framework $TMP_DIR/iphonesimulator/$PRODUCT_NAME.xcarchive/Products/Library/Frameworks/$PRODUCT_NAME.framework \
+    -framework $TMP_DIR/macos/$PRODUCT_NAME.xcarchive/Products/Library/Frameworks/$PRODUCT_NAME.framework
+
+# Cleanup
+echo "ℹ️  Removing $TMP_DIR folder..."
+rm -fr $TMP_DIR
+
+echo "🎉 Done!"

--- a/Scripts/config.sh
+++ b/Scripts/config.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+#  Created by Marko Justinek on 27/8/24.
+#  Copyright © 2024 Marko Justinek. All rights reserved.
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+#  SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+#  IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+# General
+PRODUCT_NAME="PactSwiftMockServer"
+
+# Deployment targets
+IPHONEOS_DEPLOYMENT_TARGET=15.0
+MACOSX_DEPLOYMENT_TARGET=12.0
+
+# Xcode
+MIN_SUGGESTED_XCODE_VERSION="15.4"
+MIN_SUPPORTED_XCODE_VERSION="15.4"

--- a/Scripts/install_required_tools
+++ b/Scripts/install_required_tools
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+#  Created by Marko Justinek on 27/8/24.
+#  Copyright © 2024 Marko Justinek. All rights reserved.
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+#  SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+#  IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+set -euo pipefail
+
+SOURCE_DIR="${BASH_SOURCE[0]%/*}"
+
+# "import"
+source "$SOURCE_DIR/utils.sh"
+
+REQUIRED_TOOLS=(
+  "cmake"
+  "cbindgen"
+  "doxygen"
+  "swiftlint"
+)
+
+# Install required tools
+for TOOL in "${REQUIRED_TOOLS[@]}"; do
+  if [ "$(is_installed "$TOOL")" = "true" ]; then
+    echo "👍  '$TOOL' already installed."
+  else
+    execute_command "brew install $TOOL"
+  fi
+done
+
+# Tap(s)
+if [ "$(is_installed "xcbeautify")" = "true" ]; then
+  echo "👍  'xcbeautify' already installed."
+else
+  execute_command "brew tap thii/xcbeautify https://github.com/thii/xcbeautify.git"
+  execute_command "brew install xcbeautify"
+fi
+

--- a/Scripts/rust_config.sh
+++ b/Scripts/rust_config.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+#  Created by Marko Justinek on 27/8/24.
+#  Copyright © 2024 Marko Justinek. All rights reserved.
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+#  SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+#  IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+set -eou pipefail
+
+SOURCE_DIR="${BASH_SOURCE[0]%/*}"
+
+# "import"
+source "$SOURCE_DIR/utils.sh"
+
+echo "ℹ️  List installed apple triples"
+execute_command "rustup target list | grep apple"
+
+# Config
+
+# Supported target architectures
+TARGET_ARM64_DARWIN="aarch64-apple-darwin"    # macOS running on Apple Silicon machine
+TARGET_X86_64_DARWIN="x86_64-apple-darwin"    # macOS running on Intel machine
+TARGET_ARM64_IOS="aarch64-apple-ios"          # physical iOS device
+TARGET_ARM64_IOS_SIM="aarch64-apple-ios-sim"  # iOS Simulator running on Apple Silicon machine
+TARGET_x86_64_IOS="x86_64-apple-ios"          # iOS Simulator running on Intel machine
+
+TARGETS=(
+  "$TARGET_ARM64_DARWIN"
+  "$TARGET_ARM64_IOS"
+  "$TARGET_ARM64_IOS_SIM"
+  "$TARGET_X86_64_DARWIN"
+  "$TARGET_x86_64_IOS"
+)
+
+# pact-reference/rust/pact_ffi/CMakeLists.txt uses nightly!
+TOOLCHAIN_AARCH64="nightly-aarch64-apple-darwin"
+TOOLCHAIN_X86_64="nightly-x86_64-apple-darwin"
+
+##############
+# Interface
+
+# pact-reference/rust/pact_ffi/CMakeLists.txt uses nightly!
+# If using stable, `cbindgen` command fails ¯\_(ツ)_/¯
+function rustup_install_nightly {
+  echo "⚠️  Installing nightly toolchain"
+  execute_command "rustup install nightly"
+  execute_command "rustup toolchain install nightly"
+
+  if [ "$(is_arm64)" == "false" ]; then
+    execute_command "rustup component add rustfmt --toolchain nightly"
+  fi
+}
+
+# Set default toolchain for the machine building libpact_ffi.a binaries
+function rustup_set_default_toolchain {
+  echo "ℹ️  Installing necessary rust toolchain for host machine's architecture"
+  DEFAULT_TOOLCHAIN=
+  if [ "$(is_arm64)" == "true" ]; then
+    DEFAULT_TOOLCHAIN=$TOOLCHAIN_AARCH64
+  else
+    DEFAULT_TOOLCHAIN=$TOOLCHAIN_X86_64
+  fi
+  execute_command "rustup default $DEFAULT_TOOLCHAIN"
+}
+
+# Add target architectures PactSwift supports
+function rustup_add_targets {
+  echo "ℹ️  Add necessary targets"
+  for TARGET in "${TARGETS[@]}"; do
+    echo "ℹ️  Adding target '$TARGET'"
+    execute_command "rustup target add $TARGET"
+  done
+}

--- a/Scripts/utils.sh
+++ b/Scripts/utils.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+#  Created by Marko Justinek on 27/8/24.
+#  Copyright © 2024 Marko Justinek. All rights reserved.
+#  Permission to use, copy, modify, and/or distribute this software for any
+#  purpose with or without fee is hereby granted, provided that the above
+#  copyright notice and this permission notice appear in all copies.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+#  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+#  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+#  SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+#  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+#  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+#  IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+set -euo pipefail
+
+SOURCE_DIR="${BASH_SOURCE[0]%/*}"
+
+# "import"
+source "$SOURCE_DIR/config.sh"
+
+# Utilities
+
+function is_arm64 {
+  if [ "$(uname -m)" == "arm64" ]; then
+    echo true
+  else
+    echo false
+  fi
+}
+
+function execute_command {
+  if [ $# -eq 0 ]; then
+    echo -e "No command provided"
+    exit 1
+  else
+    COMMAND="$1"
+    printf "🤖 Executing:\n   '%s'\n" "$COMMAND"
+    eval "$COMMAND"
+  fi
+}
+
+function folder_exists {
+  if [ ! -d "$1" ]; then
+    echo false
+  else
+    echo true
+  fi
+}
+
+function file_exists {
+  if [ ! -f "$1" ]; then
+    echo false
+  else
+    echo true
+  fi
+}
+
+function is_installed {
+  if command -v "$1" &> /dev/null; then
+    echo true
+  else
+    echo false
+  fi
+}
+
+# Xcode version number
+# Don't call this directly!
+function __check_xcode_version {
+  local major_version=${1:-0}
+  local minor_version=${2:-0}
+
+  local suggested_major="${MIN_SUGGESTED_XCODE_VERSION%.*}"
+  local min_supported_major="${MIN_SUPPORTED_XCODE_VERSION%.*}"
+  local min_supported_minor="${MIN_SUPPORTED_XCODE_VERSION##*.}"
+
+  return $(( (major_version >= suggested_major) || (major_version == min_supported_major && minor_version >= min_supported_minor) ))
+}
+
+# Checks for Xcode and it's version.
+# Exits with non-zero if not found or version is not supported.
+function check_xcode() {
+  if ! version="$(xcodebuild -version | sed -n '1s/^Xcode \([0-9.]*\)$/\1/p')"; then
+    echo 'error: Failed to find Xcode version.' 1>&2
+    exit 1
+  elif __check_xcode_version ${version//./ }; then # Intentinoally not double quoting to preserve number of parameters
+    echo "error: '$version' is not supported! '$MIN_SUGGESTED_XCODE_VERSION' or later is required." 1>&2;
+    exit 1
+  else
+    echo "info: Xcode '$version' installed."
+  fi
+}


### PR DESCRIPTION
Adding scripts and GitHub Actions workflows that support release process automation.

Changes in this PR:

- Add a script that pulls `PactSwiftMockServer` tag ref and builds `libpact_ffi` from Rust code in a pact-reference submodule.
- Add a script that builds an `XCFramework` off of `PactSwiftMockServer` tag.
- A GitHub Actions workflow that runs the above two scripts and opens up a Pull Request with the upgraded `XCFramework`.
